### PR TITLE
Simplifications and performance improvements

### DIFF
--- a/spyql/output_handler.py
+++ b/spyql/output_handler.py
@@ -26,6 +26,7 @@ class OutputHandler:
             self.rows_written = self.rows_written + 1
 
     def finish(self):
+        #self.writer.writerow([self.rows_written])
         self.writer.flush()
 
 class LineInLineOut(OutputHandler):

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -146,7 +146,6 @@ class Processor:
                 self.handle_header_row(_values)
                 continue
                                     
-            # print header
             if row_number == 0:
                 self.handle_1st_data_row(_values)
                 output_handler.writer.writeheader(self.make_out_cols_names(out_cols_names))

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -1,11 +1,3 @@
-# TODO: optimizations
-# [x]: single eval
-# [ ]: try to eliminate nested list
-# [x]: try to eliminate wrap row 
-# [x]: try to eliminate is instance of
-# [x]: try to eliminate execute (replace vars - needs heads + keywords)
-
-
 import csv
 import json as jsonlib
 import sys
@@ -14,7 +6,7 @@ import re
 from math import * 
 import logging
 from collections.abc import Iterable
-from itertools import islice
+from itertools import islice, chain
 
 from spyql.writer import Writer
 from spyql.output_handler import OutputHandler
@@ -61,8 +53,6 @@ class Processor:
         self.prs = prs #parsed query
         self.strings = strings
         # by default, a row does not need to be wrapped (only single cols need)
-        self.wrap_row = False 
-        self.row_instantiation_script = None  
         self.input_col_names = []
         self.colnames2idx = {}
         
@@ -96,20 +86,14 @@ class Processor:
         out_cols_names = [name for sublist in out_cols_names for name in sublist] #flatten
         return out_cols_names 
 
-    # Returns iterator over input
-    # Input iterator should be a list of lists of rows for convinience    
-    # Each row can be a list (in case of multiple columns) or a literal (single column)    
+    # Returns iterator over input (e.g. list if rows)   
+    # Each row is list with one value per column
     # e.g.
-    #   [[1],[2],[3]] is the same as 
-    #   [[1,2],[3]] and is the same as 
-    #   [[1,2,3]]: 3 rows with a single col
-    #
-    #   [[[1,'a']], [[2,'b']], [[3,'c']]] is the same as
-    #   [[[1,'a']], [[2,'b'], [3,'c']]] and is the same as
-    #   [[[1,'a'], [2,'b'], [3,'c']]]: 3 rows with 2 cols 
-    def get_input_iterators(self):        
+    #   [[1] ,[2], [3]]:                3 rows with a single col
+    #   [[1,'a'], [2,'b'], [3,'c']]:    3 rows with 2 cols 
+    def get_input_iterator(self):        
         return [[None]] #default: returns a single line with a 'null' column
-
+    
     # Default column names, e.g. col1 for the first column
     def default_col_name(self, idx):
         return f"col{idx+1}"
@@ -117,7 +101,7 @@ class Processor:
     
     # replace identifiers (column names) in sql expressions by references to `_values`
     # and put (quoted) strings back
-    def prepare_expression(self, expr):
+    def prepare_expression(self, expr):        
         if expr == '*':
             return [f"_values[{idx}]" for idx in range(self.n_input_cols)]
 
@@ -140,7 +124,7 @@ class Processor:
     def _go(self, output_handler):
         vars = globals() # to do: filter out not useful/internal vars
 
-        _values = [[]]
+        _values = []
         row_number = 0
         vars_script = None
         #json = {}
@@ -148,75 +132,64 @@ class Processor:
         # gets user-defined output cols names (with AS alias)
         out_cols_names = [c[0] for c in self.prs['select']]
         
-        cmds = []      
+        cmds = []
         
-
         explode_it_cmd = None
         explode_inst_cmd = None
         explode_path = self.prs['explode']    
         if (explode_path):
             explode_it_cmd = compile(explode_path, '', 'eval')
-            explode_inst_cmd = compile(f'{explode_path} = explode_it', '', 'exec')
-
-
-        # should not accept than 1 source, joins, etc (at least for now)
-        # input iterator is a list of lists for convinence
-        # an input iterator [[1],[2],[3]] is the same as [[1,2,3]]
-        its_list = self.get_input_iterators()
+            explode_inst_cmd = compile(f'{explode_path} = explode_it', '', 'exec')            
         
         where = None
         explode_its = [None] # 1 element by default (no explosion)
 
         logging.info("-- RESULT --")        
-        
-        for its in its_list: 
-            for it in its:        
-                _values = it                
-                
-                if not self.reading_data():
-                    self.handle_header_row(_values)
-                    continue
+
+        # should not accept more than 1 source, joins, etc (at least for now)    
+        for _values in self.get_input_iterator():
+            
+            if not self.reading_data():
+                self.handle_header_row(_values)
+                continue
+                                    
+            # print header
+            if row_number == 0:
+                self.handle_1st_data_row(_values)
+                output_handler.writer.writeheader(self.make_out_cols_names(out_cols_names))
+                if output_handler.is_done():
+                    return # in case of `limit 0`
+            
+                # TODO: move to function(s)
+                # compiles expressions for calculating outputs
+                cmds = [self.prepare_expression(c[1]) for c in self.prs['select']]  #todo: rename cmds to out_expressions        
+                cmds = [item for sublist in cmds for item in sublist] #flatten (because of '*')                    
+                cmds = compile('[' + ','.join(cmds) + ']', '<select>', 'eval')                    
+                where = self.prs['where']                
+                if (where):
+                    #TODO: check if * is not used in where... or pass argument
+                    where = compile(self.prepare_expression(where)[0], '<where>', 'eval') 
+            
+            if explode_path:
+                explode_its = eval(explode_it_cmd)
                             
-                if self.wrap_row:
-                    _values = [_values]
-                
-                # print header
-                if row_number == 0:
-                    self.handle_1st_data_row(_values)
-                    output_handler.writer.writeheader(self.make_out_cols_names(out_cols_names))
-                    if output_handler.is_done():
-                        return # in case of `limit 0`
-                
-                    # TODO: move to function(s)
-                    # compiles expressions for calculating outputs
-                    cmds = [self.prepare_expression(c[1]) for c in self.prs['select']]  #todo: rename cmds to out_expressions        
-                    cmds = [item for sublist in cmds for item in sublist] #flatten (because of '*')                    
-                    cmds = compile('[' + ','.join(cmds) + ']', '<select>', 'eval')                    
-                    where = self.prs['where']
-                    if (where):
-                        #TODO: check if * is not used in where... or pass argument
-                        where = compile(self.prepare_expression(where)[0], '<where>', 'eval') 
-                
+            for explode_it in explode_its:  
                 if explode_path:
-                    explode_its = eval(explode_it_cmd)
-                                
-                for explode_it in explode_its:  
-                    if explode_path:
-                        exec(explode_inst_cmd)
+                    exec(explode_inst_cmd)
 
-                    row_number = row_number + 1
+                row_number = row_number + 1
 
-                    vars["_values"] = _values
+                vars["_values"] = _values
 
-                    if not where or eval(where,{},vars): #filter (opt: eventually could be done before exploding)
-                        # input line is eligeble 
-                        
-                        # calculate outputs
-                        _res = eval(cmds,{},vars)
+                if not where or eval(where,{},vars): #filter (opt: eventually could be done before exploding)
+                    # input line is eligeble 
+                    
+                    # calculate outputs
+                    _res = eval(cmds,{},vars)
 
-                        output_handler.handle_result(_res) #deal with output
-                        if output_handler.is_done():
-                            return #e.g. when reached limit
+                    output_handler.handle_result(_res) #deal with output
+                    if output_handler.is_done():
+                        return #e.g. when reached limit
 
 
 class PythonExprProcessor(Processor):         
@@ -224,43 +197,42 @@ class PythonExprProcessor(Processor):
         super().__init__(prs, strings)
 
     # input is a Python expression
-    def get_input_iterators(self):
+    def get_input_iterator(self):
         e = eval(self.strings.put_strings_back(self.prs['from']))
         if e: 
             if not isinstance(e, Iterable):
                 e = [e]
-            self.wrap_row = not isinstance(e[0], Iterable)
-        return [e]
+            if not isinstance(e[0], Iterable):
+                e = [[el] for el in e]
+        return e
 
 class TextProcessor(Processor):
     def __init__(self, prs, strings):
         super().__init__(prs, strings)
-        self.wrap_row = True # since it's a single col, always wrap it
 
     # reads a text row as a row with 1 column
-    def get_input_iterators(self):
-        #return [sys.stdin] #to do: suport files
-        return [[line.rstrip("\n\r") for line in sys.stdin]]
+    def get_input_iterator(self):
+        #to do: suport files
+        return [[line.rstrip("\n\r")] for line in sys.stdin]
 
-    
     
 class JSONProcessor(Processor):
     def __init__(self, prs, strings):
         super().__init__(prs, strings)
-        self.wrap_row = True # since it's a single col, always wrap it
         self.colnames2idx.update({"json": 0}) # first column alias as json
 
-    def get_input_iterators(self):
-        return [sys.stdin] #to do: suport files
+    # 1 row = 1 json
+    def get_input_iterator(self):
+        #to do: suport files
+        return [[jsonlib.loads(line)] for line in sys.stdin]
 
 ## CSV
 class CSVProcessor(Processor):
     def __init__(self, prs, strings):
         super().__init__(prs, strings)
         self.has_header = False
-        self.wrap_row = False # since it's a multi col, it is already wraped
 
-    def get_input_iterators(self):
+    def get_input_iterator(self):
         # Part 1 reads sample to detect dialect and if has header
         # TODO: infer data type
         sample_size = 10 #make a input parameter
@@ -274,9 +246,9 @@ class CSVProcessor(Processor):
         #print(self.has_header)
         #print(dialect)        
         sample.seek(0) #rewinds the sample
-        return [
+        return chain(
             csv.reader(sample, dialect), #goes through sample again (for reading input data)
-            csv.reader(sys.stdin, dialect)] #continues to the rest of the file 
+            csv.reader(sys.stdin, dialect)) #continues to the rest of the file 
             #TODO: suport files
 
     def reading_data(self):          

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -51,10 +51,9 @@ class Processor:
 
     def __init__(self, prs, strings):
         self.prs = prs #parsed query
-        self.strings = strings
-        # by default, a row does not need to be wrapped (only single cols need)
-        self.input_col_names = []
-        self.colnames2idx = {}
+        self.strings = strings #quoted strings
+        self.input_col_names = [] #column names of the input data
+        self.colnames2idx = {} #map from column names to indexes
         
 
     # True after header, metadata, etc in input file
@@ -64,7 +63,6 @@ class Processor:
     # Action for header row (e.g. column name definition)
     def handle_header_row(self, row):
         pass
-
     
     # Action for handling the first row of data 
     def handle_1st_data_row(self, row):
@@ -97,7 +95,6 @@ class Processor:
     # Default column names, e.g. col1 for the first column
     def default_col_name(self, idx):
         return f"col{idx+1}"
-
     
     # replace identifiers (column names) in sql expressions by references to `_values`
     # and put (quoted) strings back
@@ -124,16 +121,13 @@ class Processor:
     def _go(self, output_handler):
         vars = globals() # to do: filter out not useful/internal vars
 
+        cmds = []
         _values = []
         row_number = 0
-        vars_script = None
-        #json = {}
-
+        
         # gets user-defined output cols names (with AS alias)
         out_cols_names = [c[0] for c in self.prs['select']]
-        
-        cmds = []
-        
+
         explode_it_cmd = None
         explode_inst_cmd = None
         explode_path = self.prs['explode']    
@@ -206,6 +200,7 @@ class PythonExprProcessor(Processor):
                 e = [[el] for el in e]
         return e
 
+
 class TextProcessor(Processor):
     def __init__(self, prs, strings):
         super().__init__(prs, strings)
@@ -225,6 +220,7 @@ class JSONProcessor(Processor):
     def get_input_iterator(self):
         #to do: suport files
         return [[jsonlib.loads(line)] for line in sys.stdin]
+
 
 ## CSV
 class CSVProcessor(Processor):

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -84,7 +84,7 @@ class Processor:
         out_cols_names = [name for sublist in out_cols_names for name in sublist] #flatten
         return out_cols_names 
 
-    # Returns iterator over input (e.g. list if rows)   
+    # Returns iterator over input (e.g. list of rows)   
     # Each row is list with one value per column
     # e.g.
     #   [[1] ,[2], [3]]:                3 rows with a single col
@@ -267,4 +267,3 @@ class CSVProcessor(Processor):
         s = re.sub(r'\s+', '_', s)
         
         return s
-

--- a/spyql/quotes_handler.py
+++ b/spyql/quotes_handler.py
@@ -1,0 +1,52 @@
+import re
+import random
+import string
+import logging
+
+STRING_PLACEHOLDER_LEN = 32
+
+class QuotesHandler: 
+    def __init__(self):
+        self.strings = {}
+
+    # replaces quoted strings by placeholders to make parsing easier
+    # populates dictionary of placeholders and the strings they hold
+    def extract_strings(self, query):    
+        res = []
+        quotes = [
+            r"\'(\'\'|\\.|[^'])*\'",
+            r'\"(\"\"|\\.|[^"])*\"'#,
+        #    r'\`(\`\`|\\.|[^`])*\`'
+        ]
+        
+        spans = [(0,0)]
+        for quote in quotes:
+            spans.extend([m.span() for m in re.finditer(quote, query)])
+        spans.append((len(query), 0))
+        
+        #print(spans)
+        
+        self.strings = {}
+        for i in range(len(spans)-1):
+            if i>0:            
+                sid = ''.join(random.choice(string.ascii_letters) for _ in range(STRING_PLACEHOLDER_LEN))
+                sid = f"_{sid}_"
+                res.append(sid)
+                self.strings[sid] = query[spans[i][0]+1:spans[i][1]-1] 
+                
+            res.append(query[spans[i][1]:spans[i+1][0]])
+            
+        return "".join(res)
+
+    @staticmethod
+    def string_placeholder_re():
+        return r'\_\w{%d}\_'%(STRING_PLACEHOLDER_LEN)
+
+    # replace string placeholders by their actual strings
+    def put_strings_back(self, text, quote=True):
+        quote_char = '"' if quote else ''
+        sids = {m.group(0) for m in re.finditer(self.string_placeholder_re(), text)}
+        for sid in sids:
+            text = text.replace(sid, f'{quote_char}{self.strings[sid]}{quote_char}')
+        return text    
+

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -135,8 +135,7 @@ def parse_select(sel, strings):
     return new_sel
 
 def make_expr_ready(expr, strings):    
-    return strings.put_strings_back(pythonize(expr)).strip()
-    #return pythonize(expr).strip()
+    return pythonize(expr).strip()
 
 # parse entry point
 def parse(query):
@@ -197,7 +196,7 @@ def run(query):
         
     logging.info(prs)
 
-    processor = Processor.make_processor(prs)
+    processor = Processor.make_processor(prs, strings)
 
     processor.go()
 

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -130,7 +130,7 @@ def parse_select(sel, strings):
             c = f"{make_expr_ready(c, strings)}" 
         
         #new_sel[name] = c
-        new_sel.append((name,c))
+        new_sel.append({"name": name, "expr": c})
     
     return new_sel
 
@@ -248,4 +248,3 @@ if __name__ == "__main__":
 
     # p.sort_stats(SortKey.CUMULATIVE).dump_stats('spyql.stats.cum')
     # p.sort_stats(SortKey.TIME).dump_stats('spyql.stats.time')
-    

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -238,6 +238,8 @@ def main():
 if __name__ == "__main__":    
     main()
 
+    ## For profiling:
+    #
     # import cProfile    
     # import pstats
     # from pstats import SortKey
@@ -246,3 +248,4 @@ if __name__ == "__main__":
 
     # p.sort_stats(SortKey.CUMULATIVE).dump_stats('spyql.stats.cum')
     # p.sort_stats(SortKey.TIME).dump_stats('spyql.stats.time')
+    

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -123,11 +123,11 @@ def parse_select(sel, strings):
             c = c[:(sas.span()[0])]
 
         if c.strip() == '*':
-            c = "_values"
+            c = "*"
             name = '*'
         else:            
             name = strings.put_strings_back(name, quote=False)
-            c = f"[{make_expr_ready(c, strings)}]" 
+            c = f"{make_expr_ready(c, strings)}" 
         
         #new_sel[name] = c
         new_sel.append((name,c))
@@ -219,7 +219,7 @@ def print_select_syntax():
 
 def main():
     #sys.tracebacklimit = 0 # no exception traces
-    logging.basicConfig(level=logging.INFO)
+    #logging.basicConfig(level=logging.INFO)
     #logging.basicConfig(level=logging.DEBUG)
 
     #default query for simple testing:


### PR DESCRIPTION
After running a profiler did some changes and simplifications. 

Highlights:
- Use of flat lists for rows (`_values` is now a list instead of a list of lists)
- Input over a single iterator (instead of list of iterators)
- Column names are replaced by direct access to the `_values` list in the SQL expression (instead of instantiating variables with the column names for each row) - part of the processing of the SQL expression had to move to the `processor` class
- One evaluation per line (instead of one per column)