### PR TITLE
Better output col names

### DIFF
--- a/spyql/log.py
+++ b/spyql/log.py
@@ -3,6 +3,8 @@ import asciichartpy as colors
 import sys
 import json
 
+from spyql.utils import quote_ifstr
+
 error_on_warning = False  # TODO command line arg
 
 
@@ -71,10 +73,6 @@ def user_debug_dict(message, adict):
     Reports (debug) information, printing a dict as a pretty json.
     """
     user_debug(message, json.dumps(adict, indent=4))
-
-
-def quote_ifstr(s):
-    return f"'{s}'" if isinstance(s, str) else s
 
 
 def user_warning4func(message, exception, *args, **kwargs):

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -12,6 +12,8 @@ from spyql.writer import Writer
 from spyql.output_handler import OutputHandler
 from spyql.nulltype import *
 from spyql.log import *
+from spyql.utils import make_str_valid_varname
+
 
 from datetime import datetime, date, timezone
 import pytz
@@ -402,20 +404,4 @@ class CSVProcessor(Processor):
         return (not self.has_header) or (self.input_col_names)
 
     def handle_header_row(self, row):
-        self.input_col_names = [self.make_str_valid_varname(val) for val in row]
-
-    def make_str_valid_varname(self, s):
-        # remove invalid characters (except spaces in-between)
-        s = re.sub(r"[^0-9a-zA-Z_\s]", "", s).strip()
-
-        # remove leading characters that are not letters or underscore
-        # s = re.sub(r'^[^a-zA-Z_]+', '', s)
-
-        # if first char is not letter or underscore then add underscore to make it valid
-        if not re.match("^[a-zA-Z_]", s):
-            s = "_" + s
-
-        # replace spaces by underscores (instead of dropping spaces) for readability
-        s = re.sub(r"\s+", "_", s)
-
-        return s
+        self.input_col_names = [make_str_valid_varname(val) for val in row]

--- a/spyql/quotes_handler.py
+++ b/spyql/quotes_handler.py
@@ -1,7 +1,6 @@
 import re
 import random
 import string
-import logging
 
 STRING_PLACEHOLDER_LEN = 32
 

--- a/spyql/utils.py
+++ b/spyql/utils.py
@@ -1,0 +1,22 @@
+import re
+
+
+def quote_ifstr(s):
+    return f"'{s}'" if isinstance(s, str) else s
+
+
+def make_str_valid_varname(s):
+    # remove invalid characters (except spaces in-between)
+    s = re.sub(r"[^0-9a-zA-Z_\s]", "", s).strip()
+
+    # remove leading characters that are not letters or underscore
+    # s = re.sub(r'^[^a-zA-Z_]+', '', s)
+
+    # if first char is not letter or underscore then add underscore to make it valid
+    if not re.match("^[a-zA-Z_]", s):
+        s = "_" + s
+
+    # replace spaces by underscores (instead of dropping spaces) for readability
+    s = re.sub(r"\s+", "_", s)
+
+    return s

--- a/spyql/utils.py
+++ b/spyql/utils.py
@@ -7,16 +7,13 @@ def quote_ifstr(s):
 
 def make_str_valid_varname(s):
     # remove invalid characters (except spaces in-between)
-    s = re.sub(r"[^0-9a-zA-Z_\s]", "", s).strip()
+    s = re.sub(r"[^0-9a-zA-Z_\s]", " ", s).strip()
 
-    # remove leading characters that are not letters or underscore
-    # s = re.sub(r'^[^a-zA-Z_]+', '', s)
+    # replace spaces by underscores (instead of dropping spaces) for readability
+    s = re.sub(r"\s+", "_", s)
 
     # if first char is not letter or underscore then add underscore to make it valid
     if not re.match("^[a-zA-Z_]", s):
         s = "_" + s
-
-    # replace spaces by underscores (instead of dropping spaces) for readability
-    s = re.sub(r"\s+", "_", s)
 
     return s

--- a/spyql/writer.py
+++ b/spyql/writer.py
@@ -1,9 +1,10 @@
 import csv
 import json as jsonlib
 import pickle
-from spyql.log import user_error
 from tabulate import tabulate  # https://pypi.org/project/tabulate/
 import asciichartpy as chart
+
+from spyql.log import user_error
 from spyql.nulltype import NULL
 
 

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -75,19 +75,19 @@ def test_myoutput(capsys, monkeypatch):
 
     ## single column
     # int
-    eq_test_1row("SELECT 1", {"out1": 1})
-    eq_test_1row("SELECT 1+2", {"out1": 3})
+    eq_test_1row("SELECT 1", {"_1": 1})
+    eq_test_1row("SELECT 1+2", {"_1_2": 3})
 
     # float
-    eq_test_1row("SELECT 1.1", {"out1": 1.1})
-    eq_test_1row("SELECT 1+0.2", {"out1": 1.2})
+    eq_test_1row("SELECT 1.1", {"_1_1": 1.1})
+    eq_test_1row("SELECT 1+0.2", {"_1_0_2": 1.2})
 
     # text
-    eq_test_1row("SELECT '1'", {"out1": "1"})
-    eq_test_1row("SELECT '1'+'2'", {"out1": "12"})
+    eq_test_1row("SELECT '1'", {"_1": "1"})
+    eq_test_1row("SELECT '1'+'2'", {"_1_2": "12"})
 
     # two columns with differemt data types
-    eq_test_1row("SELECT '1', 2", {"out1": "1", "out2": 2})
+    eq_test_1row("SELECT '1', 2", {"_1": "1", "_2": 2})
 
     # alias
     eq_test_1row("SELECT '1' as a, 2 AS Ola", {"a": "1", "Ola": 2})
@@ -159,18 +159,18 @@ def test_myoutput(capsys, monkeypatch):
     )
 
     # NULL
-    eq_test_1row("SELECT NULL", {"out1": NULL})
-    eq_test_1row("SELECT NULL+1", {"out1": NULL})
-    eq_test_1row("SELECT int('')", {"out1": NULL})
-    eq_test_1row("SELECT coalesce(NULL,2)", {"out1": 2})
-    eq_test_1row("SELECT coalesce(3,2)", {"out1": 3})
-    eq_test_1row("SELECT nullif(1,1)", {"out1": NULL})
-    eq_test_1row("SELECT nullif(3,2)", {"out1": 3})
+    eq_test_1row("SELECT NULL", {"NULL": NULL})
+    eq_test_1row("SELECT NULL+1", {"NULL_1": NULL})
+    eq_test_1row("SELECT int('')", {"int": NULL})
+    eq_test_1row("SELECT coalesce(NULL,2)", {"coalesce_NULL_2": 2})
+    eq_test_1row("SELECT coalesce(3,2)", {"coalesce_3_2": 3})
+    eq_test_1row("SELECT nullif(1,1)", {"nullif_1_1": NULL})
+    eq_test_1row("SELECT nullif(3,2)", {"nullif_3_2": 3})
 
     # JSON input and NULLs
-    eq_test_1row("SELECT json->a FROM json", {"out1": 1}, data='{"a": 1}\n')
-    eq_test_1row("SELECT json->a FROM json", {"out1": NULL}, data='{"a": null}\n')
-    eq_test_1row("SELECT json->b FROM json", {"out1": NULL}, data='{"a": 1}\n')
+    eq_test_1row("SELECT json->a FROM json", {"a": 1}, data='{"a": 1}\n')
+    eq_test_1row("SELECT json->a FROM json", {"a": NULL}, data='{"a": null}\n')
+    eq_test_1row("SELECT json->b FROM json", {"b": NULL}, data='{"a": 1}\n')
 
     # CSV input and NULLs
     eq_test_nrows(


### PR DESCRIPTION
This PR introduces automatic inference of output column names (whenever alias are not provided).
Output column names are derived from the expressions, so that they only contain letters, numbers and underscores, and do not start by a numeric character. 
In addition, the json variable is removed when accessing json fields. Some examples:

| expression | output column name |
|-----|-----|
| `json->hello->world` | `hello_world`|
| `json['hello']['world']` | `hello_world`|
| `price - discount` | `price_discount` |
| `2 * x + 1` | `_2_x_1` |
| `x * 2 + 1` | `x_2_1` |

Closes #15 .
Closes #16 .