### PR TITLE
IO options

### DIFF
--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -227,9 +227,9 @@ class Processor:
             )
 
     # main
-    def go(self):
+    def go(self, output_options):
         output_handler = OutputHandler.make_handler(self.prs)
-        writer = Writer.make_writer(self.prs["to"], sys.stdout, {})  # TODO add options
+        writer = Writer.make_writer(self.prs["to"], sys.stdout, output_options)
         output_handler.set_writer(writer)
         nrows_in, nrows_out = self._go(output_handler)
         output_handler.finish()

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -7,6 +7,7 @@ import re
 from math import *
 from collections.abc import Iterable
 from itertools import islice, chain
+from io import StringIO
 
 from spyql.writer import Writer
 from spyql.output_handler import OutputHandler
@@ -25,26 +26,29 @@ import pytz
 
 class Processor:
     @staticmethod
-    def make_processor(prs, strings):
+    def make_processor(prs, strings, input_options):
         """
         Factory for making a file processor based on the parsed query
         """
-        processor_name = prs["from"]
-        if not processor_name:
-            return Processor(prs, strings)
+        try:
+            processor_name = prs["from"]
+            if not processor_name:
+                return Processor(prs, strings, **input_options)
 
-        processor_name = processor_name.upper()
+            processor_name = processor_name.upper()
 
-        if processor_name == "JSON":
-            return JSONProcessor(prs, strings)
-        if processor_name == "CSV":
-            return CSVProcessor(prs, strings)
-        if processor_name == "TEXT":  # single col
-            return TextProcessor(prs, strings)
-        if processor_name == "SPY":
-            return SpyProcessor(prs, strings)
+            if processor_name == "JSON":
+                return JSONProcessor(prs, strings, **input_options)
+            if processor_name == "CSV":
+                return CSVProcessor(prs, strings, **input_options)
+            if processor_name == "TEXT":  # single col
+                return TextProcessor(prs, strings, **input_options)
+            if processor_name == "SPY":
+                return SpyProcessor(prs, strings, **input_options)
 
-        return PythonExprProcessor(prs, strings)
+            return PythonExprProcessor(prs, strings, **input_options)
+        except TypeError as e:
+            user_error(f"Could not create '{processor_name}' processor", e)
 
     def __init__(self, prs, strings):
         self.prs = prs  # parsed query
@@ -355,8 +359,10 @@ class SpyProcessor(Processor):
 
 
 class JSONProcessor(Processor):
-    def __init__(self, prs, strings):
+    def __init__(self, prs, strings, **options):
         super().__init__(prs, strings)
+        jsonlib.loads('{"a": 1}', **options)  # test options
+        self.options = options
         self.translations.update({"json": "_values[0]"})  # first column alias as json
 
     # 1 row = 1 json
@@ -366,38 +372,54 @@ class JSONProcessor(Processor):
         # this might not be the most efficient way of converting None -> NULL, look at:
         # https://stackoverflow.com/questions/27695901/python-jsondecoder-custom-translation-of-null-type
         return (
-            [jsonlib.loads(line, object_hook=lambda x: NullSafeDict(x))]
+            [jsonlib.loads(line, object_hook=lambda x: NullSafeDict(x), **self.options)]
             for line in sys.stdin
         )
 
 
 ## CSV
 class CSVProcessor(Processor):
-    def __init__(self, prs, strings):
+    def __init__(self, prs, strings, sample_size=10, header=None, **options):
         super().__init__(prs, strings)
+        self.sample_size = sample_size
+        self.has_header = header
+        self.options = options
+        csv.reader(StringIO("test"), **self.options)  # test options
 
     def get_input_iterator(self):
         # Part 1 reads sample to detect dialect and if has header
         # TODO: infer data type
-        sample_size = 10  # make a input parameter
-        # saves sample
+        # TODO force linedelimiter to be new line char set
+
+        # saves sample to a string
+        # NOTE if dialect is given and type detection is off we should not need a sample
         sample = io.StringIO()
-        for line in list(islice(sys.stdin, sample_size)):  # TODO: support files
+        for line in list(islice(sys.stdin, self.sample_size)):  # TODO: support files
             sample.write(line)
         sample_val = sample.getvalue()
         if not sample_val:
             return []
-        dialect = csv.Sniffer().sniff(sample_val)
-        self.has_header = csv.Sniffer().has_header(sample_val)
+        if not self.options:
+            # CSV dialect and header detection
+            try:
+                self.options = {"dialect": csv.Sniffer().sniff(sample_val)}
+            except Exception as e:
+                user_error("Could not detect CSV dialect from input", e)
+            if self.has_header == None:
+                try:
+                    self.has_header = csv.Sniffer().has_header(sample_val)
+                except Exception as e:
+                    user_error("Could not detect if input CSV has header", e)
+        elif self.has_header == None:
+            self.has_header = True  # default if dialect is not automatically detected
 
         sample.seek(0)  # rewinds the sample
         return chain(
             csv.reader(
-                sample, dialect
+                sample, **self.options
             ),  # goes through sample again (for reading input data)
-            csv.reader(sys.stdin, dialect),
+            csv.reader(sys.stdin, **self.options),
         )  # continues to the rest of the file
-        # TODO: suport files
 
     def reading_data(self):
         return (not self.has_header) or (self.input_col_names)

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -232,7 +232,7 @@ def run(query, input_opt={}, output_opt={}):
     spyql.log.user_debug_dict("Parsed query", prs)
     spyql.log.user_debug_dict("Strings", strings.strings)
 
-    processor = Processor.make_processor(prs, strings)
+    processor = Processor.make_processor(prs, strings, input_opt)
 
     processor.go(output_opt)
 

--- a/spyql/spyql.py
+++ b/spyql/spyql.py
@@ -207,10 +207,6 @@ def parse(query):
     return (prs, strings)
 
 
-def re_search_first(*argv):
-    return re.search(*argv).group(0)
-
-
 def parse_options(ctx, param, options):
     options = [opt.split("=", 1) for opt in options]
     for opt in options:

--- a/spyql/utils.py
+++ b/spyql/utils.py
@@ -17,3 +17,10 @@ def make_str_valid_varname(s):
         s = "_" + s
 
     return s
+
+
+def try2eval(val, globals={}, locals={}):
+    try:
+        return eval(val, globals, locals)
+    except:
+        return val

--- a/spyql/writer.py
+++ b/spyql/writer.py
@@ -92,8 +92,8 @@ class SimpleJSONWriter(Writer):
 
 class CollectWriter(Writer):
     """
-    Abstract writer that collects all records into a (in-memory) list and dumps the
-    all output records at the end.
+    Abstract writer that collects all records into a (in-memory) list and dumps all
+    the output records at the end.
     Child classes must implement the `writerows` method.
     """
 

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -65,6 +65,7 @@ def test_myoutput(capsys, monkeypatch):
         assert spy2py_str(get_output(capsys, True)) == list_of_struct2py_str(
             expectation
         )
+        # TODO include pretty
 
     def eq_test_1row(query, expectation, data=None):
         eq_test_nrows(query, [expectation], data)
@@ -270,7 +271,7 @@ def test_sql_output(capsys):
     """
     conn = sqlite3.connect(":memory:")
     conn.cursor().execute(
-        """CREATE TABLE table_name(
+        """CREATE TABLE test1(
         aint int,
         afloat numeric(2,1),
         aintnull int,
@@ -292,10 +293,11 @@ def test_sql_output(capsys):
             {'a':col1, 'a2': col1*2} as adict
         FROM [1,2,3]
         TO sql
-    """
+        """,
+        output_opt={"table": "test1", "chunk_size": 3},
     )
     conn.cursor().execute(get_output(capsys))
-    result = conn.cursor().execute("select * from table_name").fetchall()
+    result = conn.cursor().execute("select * from test1").fetchall()
     conn.close()
     expectation = [
         (1, 0.51, 100, None, "abc1", "[1, 2, 3]", "{'a': 1, 'a2': 2}"),

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -364,8 +364,3 @@ def test_plot_output():
     res = run_spyql("SELECT col1 as abc, col1*2 FROM range(20) TO plot")
     assert res.exit_code == 0  # just checking that it does not break...
 
-
-def test_profile():
-    res = run_spyql("SELECT 1", ["--profile"])
-    assert res.exit_code == 0  # just checking that it does not break...
-    # TODO check if profile file was created

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -1,88 +1,94 @@
-from tabulate import tabulate
+from click.testing import CliRunner
+import spyql.spyql
+import spyql.log
 from spyql.writer import SpyWriter
 from spyql.processor import SpyProcessor
-from spyql.spyql import run
 from spyql.nulltype import NULL, NullSafeDict
-import spyql.log
+from tabulate import tabulate
 import json
 import csv
 import io
-import pytest
 import sqlite3
 
 
-def get_json_output(capsys):
+def json_output(out):
     return [
         json.loads(line, object_hook=lambda x: NullSafeDict(x))
-        for line in capsys.readouterr().out.splitlines()
+        for line in out.splitlines()
     ]
 
 
-def get_output(capsys, has_header=False):
-    out = capsys.readouterr().out
+def txt_output(out, has_header=False):
     if has_header and out.count("\n") == 1:
-        return ""  # special case when outputs is the header row (output has no data)
-    return out
+        return []  # special case when outputs is the header row (output has no data)
+    return out.splitlines()
 
 
-def list_of_struct2pretty_str(vals):
+def list_of_struct2pretty(vals):
     if not vals:
-        return ""
-    return tabulate(vals, headers="keys", tablefmt="simple") + "\n"
+        return []
+    return (tabulate(vals, headers="keys", tablefmt="simple") + "\n").splitlines()
 
 
-def list_of_struct2csv_str(vals):
+def list_of_struct2csv(vals):
     if not vals:
-        return ""
+        return []
     out_str = io.StringIO()
     writer = csv.DictWriter(out_str, vals[0].keys())
     writer.writeheader()
     for val in vals:
         writer.writerow(val)
-    return out_str.getvalue()
+    return out_str.getvalue().splitlines()
 
 
-def list_of_struct2py_str(vals):
+def list_of_struct2py(vals):
     if not vals:
-        return ""
+        return []
     header = [str(list(vals[0].keys()))]
     rows = [str(list(val.values())) for val in vals]
-    return "\n".join(header + rows)
+    return header + rows
 
 
-def spy2py_str(lines):
-    return "\n".join(
-        [str(SpyProcessor.unpack_line(line)) for line in lines.splitlines()]
-    )
+def spy2py(lines):
+    return [str(SpyProcessor.unpack_line(line)) for line in lines]
 
 
-def test_myoutput(capsys, monkeypatch):
-    def eq_test_nrows(query, expectation, data=None, **kwargs):
-        if data:
-            monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO json", **kwargs)
-        assert get_json_output(capsys) == expectation
-        if data:
-            monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO csv", **kwargs)
-        assert get_output(capsys, True) == list_of_struct2csv_str(expectation)
-        if data:
-            monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO spy", **kwargs)
-        assert spy2py_str(get_output(capsys, True)) == list_of_struct2py_str(
-            expectation
-        )
-        if data:
-            monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO pretty", **kwargs)
-        assert get_output(capsys, True) == list_of_struct2pretty_str(expectation)
+def run_spyql(query="", options=[], data=None, runner=CliRunner(), exception=True):
+    return runner.invoke(spyql.spyql.main, options + [query], input=data)
 
-    def eq_test_1row(query, expectation, data=None, **kwargs):
-        eq_test_nrows(query, [expectation], data, **kwargs)
 
-    def exception_test(query, anexception, **kwargs):
-        with pytest.raises(anexception):
-            run(query, **kwargs)
+def eq_test_nrows(query, expectation, data=None, options=[]):
+    runner = CliRunner()
+
+    res = run_spyql(query + " TO json", options, data, runner)
+    assert json_output(res.output) == expectation
+    assert res.exit_code == 0
+
+    res = run_spyql(query + " TO csv", options, data, runner)
+    assert txt_output(res.output, True) == list_of_struct2csv(expectation)
+    assert res.exit_code == 0
+
+    res = run_spyql(query + " TO spy", options, data, runner)
+    assert spy2py(txt_output(res.output, True)) == list_of_struct2py(expectation)
+    assert res.exit_code == 0
+
+    res = run_spyql(query + " TO pretty", options, data, runner)
+    assert txt_output(res.output, True) == list_of_struct2pretty(expectation)
+    assert res.exit_code == 0
+
+
+def eq_test_1row(query, expectation, **kwargs):
+    eq_test_nrows(query, [expectation], **kwargs)
+
+
+def exception_test(query, anexception, **kwargs):
+    res = run_spyql(query, **kwargs)
+    assert res.exit_code != 0
+    assert isinstance(res.exception, anexception)
+
+
+######  TESTS  ######
+def test_basic():
 
     ## single column
     # int
@@ -169,7 +175,8 @@ def test_myoutput(capsys, monkeypatch):
         {"calc": 30, "two": 2},
     )
 
-    # NULL
+
+def test_null():
     eq_test_1row("SELECT NULL", {"NULL": NULL})
     eq_test_1row("SELECT NULL+1", {"NULL_1": NULL})
     eq_test_1row("SELECT int('')", {"int": NULL})
@@ -178,10 +185,27 @@ def test_myoutput(capsys, monkeypatch):
     eq_test_1row("SELECT nullif(1,1)", {"nullif_1_1": NULL})
     eq_test_1row("SELECT nullif(3,2)", {"nullif_3_2": 3})
 
+
+def test_processors():
     # JSON input and NULLs
     eq_test_1row("SELECT json->a FROM json", {"a": 1}, data='{"a": 1}\n')
     eq_test_1row("SELECT json->a FROM json", {"a": NULL}, data='{"a": null}\n')
     eq_test_1row("SELECT json->b FROM json", {"b": NULL}, data='{"a": 1}\n')
+
+    # JSON EXPLODE
+    eq_test_nrows(
+        "SELECT json->a, json->b FROM json EXPLODE json->a",
+        [
+            {"a": 1, "b": "three"},
+            {"a": 2, "b": "three"},
+            {"a": 3, "b": "three"},
+            {"a": 4, "b": "four"},
+        ],
+        data=(
+            '{"a": [1, 2, 3], "b": "three"}\n{"a": [], "b": "none"}\n{"a": [4], "b":'
+            ' "four"}\n'
+        ),
+    )
 
     # CSV input and NULLs
     eq_test_nrows(
@@ -198,13 +222,13 @@ def test_myoutput(capsys, monkeypatch):
         "SELECT int(a) as a FROM csv",
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
         data="a,b,c\n,2,3\n4,5,6\noops,8,9",
-        input_opt={"delimiter": ","},
+        options=["-Idelimiter=,"],
     )
     eq_test_nrows(
         "SELECT int(col1) as a FROM csv",
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
         data=",2,3\n4,5,6\noops,8,9",
-        input_opt={"delimiter": ",", "header": False},
+        options=["-Idelimiter=,", "-Iheader=False"],
     )
 
     # Text input and NULLs
@@ -256,9 +280,8 @@ def test_myoutput(capsys, monkeypatch):
         ),
     )
 
-    # SQL output
 
-    ## custom syntax
+def test_custom_syntax():
     # easy access to dic fields
     eq_test_1row(
         "SELECT col1->three * 2 as six, col1->'twenty one' + 3 AS twentyfour,"
@@ -267,7 +290,8 @@ def test_myoutput(capsys, monkeypatch):
         {"six": 6, "twentyfour": 24, "caps": "HELLO WORLD"},
     )
 
-    ## Errors
+
+def test_errors():
     # TODO find way to test custom error output
     exception_test("SELECT 2 + ''", TypeError)
     exception_test("SELECT abc", NameError)
@@ -278,18 +302,19 @@ def test_myoutput(capsys, monkeypatch):
     exception_test("WHERE True", SyntaxError)
     exception_test("SELECT 1 TO _this_writer_does_not_exist_", SyntaxError)
     exception_test("SELECT 1 FROM [1,2,,]]", SyntaxError)
-    exception_test("SELECT 1 TO csv", TypeError, output_opt={"unexisting_option", 1})
-    exception_test("SELECT 1 TO plot", TypeError, output_opt={"unexisting_option": 1})
-    exception_test("SELECT 1 TO csv", TypeError, output_opt={"delimiter", "bad"})
+    exception_test("SELECT 1 TO csv", TypeError, options=["-Ounexisting_option=1"])
+    exception_test("SELECT 1 TO plot", TypeError, options=["-Ounexisting_option=1"])
+    exception_test("SELECT 1 FROM csv", TypeError, options=["-Iunexisting_option=1"])
+    exception_test("SELECT 1 FROM spy", TypeError, options=["-Iunexisting_option=1"])
+    exception_test("SELECT 1 TO csv", TypeError, options=["-Odelimiter=bad"])
+    exception_test("SELECT 1 FROM csv", TypeError, options=["-Idelimiter=bad"])
+    exception_test("SELECT 1 TO csv", SystemExit, options=["-Ola"])
+    exception_test("SELECT int('abcde')", ValueError, options=["-Werror"])
+    exception_test("SELECT float('')", ValueError, options=["-Werror"])
+    exception_test("SELECT float('')", ValueError, options=["-Werror"])
 
-    spyql.log.error_on_warning = True
-    exception_test("SELECT int('abcde')", ValueError)
-    spyql.log.error_on_warning = False
 
-    # TODO test explode
-
-
-def test_sql_output(capsys):
+def test_sql_output():
     """
     Writes to an in memory sqlite DB and reads back to test
     """
@@ -305,8 +330,8 @@ def test_sql_output(capsys):
         adict text)
     """
     )
-    run(
-        """
+
+    query = """
         SELECT
             col1 as aint,
             col1/2 + 0.01 as afloat,
@@ -317,10 +342,14 @@ def test_sql_output(capsys):
             {'a':col1, 'a2': col1*2} as adict
         FROM [1,2,3]
         TO sql
-        """,
-        output_opt={"table": "test1", "chunk_size": 3},
-    )
-    conn.cursor().execute(get_output(capsys))
+        """
+
+    res = run_spyql(query, ["-Otable=test1", "-Ochunk_size=2"])
+    assert res.exit_code == 0
+    for insert_stat in res.output.splitlines():
+        # run inserts from spyql in sqlite
+        conn.cursor().execute(insert_stat)
+
     result = conn.cursor().execute("select * from test1").fetchall()
     conn.close()
     expectation = [
@@ -329,3 +358,14 @@ def test_sql_output(capsys):
         (3, 1.51, 100, "hello", "abc3", "[1, 2, 3]", "{'a': 3, 'a2': 6}"),
     ]
     assert expectation == result
+
+
+def test_plot_output():
+    res = run_spyql("SELECT col1 as abc, col1*2 FROM range(20) TO plot")
+    assert res.exit_code == 0  # just checking that it does not break...
+
+
+def test_profile():
+    res = run_spyql("SELECT 1", ["--profile"])
+    assert res.exit_code == 0  # just checking that it does not break...
+    # TODO check if profile file was created

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -57,28 +57,28 @@ def spy2py_str(lines):
 
 
 def test_myoutput(capsys, monkeypatch):
-    def eq_test_nrows(query, expectation, data=None):
+    def eq_test_nrows(query, expectation, data=None, **kwargs):
         if data:
             monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO json")
+        run(query + " TO json", **kwargs)
         assert get_json_output(capsys) == expectation
         if data:
             monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO csv")
+        run(query + " TO csv", **kwargs)
         assert get_output(capsys, True) == list_of_struct2csv_str(expectation)
         if data:
             monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO spy")
+        run(query + " TO spy", **kwargs)
         assert spy2py_str(get_output(capsys, True)) == list_of_struct2py_str(
             expectation
         )
         if data:
             monkeypatch.setattr("sys.stdin", io.StringIO(data))
-        run(query + " TO pretty")
+        run(query + " TO pretty", **kwargs)
         assert get_output(capsys, True) == list_of_struct2pretty_str(expectation)
 
-    def eq_test_1row(query, expectation, data=None):
-        eq_test_nrows(query, [expectation], data)
+    def eq_test_1row(query, expectation, data=None, **kwargs):
+        eq_test_nrows(query, [expectation], data, **kwargs)
 
     def exception_test(query, anexception, **kwargs):
         with pytest.raises(anexception):
@@ -194,6 +194,18 @@ def test_myoutput(capsys, monkeypatch):
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
         data="a,b,c\n,2,3\n4,5,6\noops,8,9",
     )
+    eq_test_nrows(
+        "SELECT int(a) as a FROM csv",
+        [{"a": NULL}, {"a": 4}, {"a": NULL}],
+        data="a,b,c\n,2,3\n4,5,6\noops,8,9",
+        input_opt={"delimiter": ","},
+    )
+    eq_test_nrows(
+        "SELECT int(col1) as a FROM csv",
+        [{"a": NULL}, {"a": 4}, {"a": NULL}],
+        data=",2,3\n4,5,6\noops,8,9",
+        input_opt={"delimiter": ",", "header": False},
+    )
 
     # Text input and NULLs
     eq_test_nrows(
@@ -275,7 +287,6 @@ def test_myoutput(capsys, monkeypatch):
     spyql.log.error_on_warning = False
 
     # TODO test explode
-    # TODO test CSV without header
 
 
 def test_sql_output(capsys):

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -363,4 +363,3 @@ def test_sql_output():
 def test_plot_output():
     res = run_spyql("SELECT col1 as abc, col1*2 FROM range(20) TO plot")
     assert res.exit_code == 0  # just checking that it does not break...
-

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -1,3 +1,4 @@
+from tabulate import tabulate
 from spyql.writer import SpyWriter
 from spyql.processor import SpyProcessor
 from spyql.spyql import run
@@ -22,6 +23,12 @@ def get_output(capsys, has_header=False):
     if has_header and out.count("\n") == 1:
         return ""  # special case when outputs is the header row (output has no data)
     return out
+
+
+def list_of_struct2pretty_str(vals):
+    if not vals:
+        return ""
+    return tabulate(vals, headers="keys", tablefmt="simple") + "\n"
 
 
 def list_of_struct2csv_str(vals):
@@ -65,7 +72,10 @@ def test_myoutput(capsys, monkeypatch):
         assert spy2py_str(get_output(capsys, True)) == list_of_struct2py_str(
             expectation
         )
-        # TODO include pretty
+        if data:
+            monkeypatch.setattr("sys.stdin", io.StringIO(data))
+        run(query + " TO pretty")
+        assert get_output(capsys, True) == list_of_struct2pretty_str(expectation)
 
     def eq_test_1row(query, expectation, data=None):
         eq_test_nrows(query, [expectation], data)

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -80,9 +80,9 @@ def test_myoutput(capsys, monkeypatch):
     def eq_test_1row(query, expectation, data=None):
         eq_test_nrows(query, [expectation], data)
 
-    def exception_test(query, anexception):
+    def exception_test(query, anexception, **kwargs):
         with pytest.raises(anexception):
-            run(query)
+            run(query, **kwargs)
 
     ## single column
     # int
@@ -266,6 +266,9 @@ def test_myoutput(capsys, monkeypatch):
     exception_test("WHERE True", SyntaxError)
     exception_test("SELECT 1 TO _this_writer_does_not_exist_", SyntaxError)
     exception_test("SELECT 1 FROM [1,2,,]]", SyntaxError)
+    exception_test("SELECT 1 TO csv", TypeError, output_opt={"unexisting_option", 1})
+    exception_test("SELECT 1 TO plot", TypeError, output_opt={"unexisting_option": 1})
+    exception_test("SELECT 1 TO csv", TypeError, output_opt={"delimiter", "bad"})
 
     spyql.log.error_on_warning = True
     exception_test("SELECT int('abcde')", ValueError)


### PR DESCRIPTION
- Added command-line options to allow formatting/controlling input and output.
- Options can either be specific to spyql (e.g. tell if a csv has or not header file) or can be a keyword argument of the function used to write/read output/input (e.g. csv delimiter char). This allows reusing all the options available in the libraries to read/write CSVs, JSONs, etc.
- Errors are thrown if an option is not supported by the writer/processor
- Input options have the format: `-I<kwarg>=<value>` where `kwarg` is a keyword argument and `value` is either a string or a python expression (there is a 1st attempt evaluating `value` as a python expression and if it fails the argument is considered to be a string). e.g. `-Iheader=False` passes the option `header` with boolean value `False` to the processor; both `-Idelimiter=,` and `-Idelimiter=","`  pass the option `delimiter` with string value `","` to the processor; `-Ichunk_size="int(123*0.05)"` passes the integer value 6 to option `chunk_size`
- Output options have the format: `-O<kwarg>=<value>` (same behaviour as for input options)
- Tests were refactored to use the click library, allowing to simplify code and include testing command-line options

TODO: documentation

Closes issue #19 
Closes issue #14 