### PR TITLE
Type inference and improved meta layer

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.4.0 (2021-11-30)
+------------------
+* Added data type inference when reading CSVs
+* Added meta layer to access column names and values
+* Improved handling of NULLs on pretty and plot writers
+
+
 0.3.0 (2021-11-18)
 ------------------
 * Added aggretation/window functions
@@ -9,12 +16,14 @@ History
 * Added SELECT DISTINCT modifier
 * Added SELECT PARTIALS modifier for running analytical/window queries
 
+
 0.2.0 (2021-10-23)
 ------------------
 
 * Added IMPORT clause
 * Added ORDER BY clause
 * Added support for init file
+
 
 0.1.0 (2021-08-19)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-0.4.0 (2021-11-30)
+0.4.0 (2021-12-02)
 ------------------
 * Added data type inference when reading CSVs
 * Added meta layer to access column names and values

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -435,7 +435,7 @@ class JSONProcessor(Processor):
         super().__init__(prs, strings)
         jsonlib.loads('{"a": 1}', **options)  # test options
         self.options = options
-        self.translations.update({"json": "_values[0]"})  # first column alias as json
+        self.input_col_names = ["json"]
 
     # 1 row = 1 json
     def get_input_iterator(self):

--- a/spyql/writer.py
+++ b/spyql/writer.py
@@ -3,6 +3,7 @@ import json as jsonlib
 import pickle
 from tabulate import tabulate  # https://pypi.org/project/tabulate/
 import asciichartpy as chart
+from math import nan
 
 from spyql.log import user_error
 from spyql.nulltype import NULL
@@ -101,8 +102,11 @@ class CollectWriter(Writer):
         super().__init__(outputfile)
         self.all_rows = []  # needs to store output in memory
 
+    def transformvalue(self, value):
+        return None if value is NULL else value
+
     def writerow(self, row):
-        self.all_rows.append(row)  # accumulates
+        self.all_rows.append([self.transformvalue(val) for val in row])  # accumulates
 
     def writerows(self, rows):
         raise NotImplementedError
@@ -136,6 +140,9 @@ class PlotWriter(CollectWriter):
         super().__init__(outputfile)
         self.header_on = header
         self.height = height
+
+    def transformvalue(self, value):
+        return nan if value is NULL or value is None else value
 
     def writerows(self, rows):
         colors = [

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -529,6 +529,7 @@ def test_processors():
             ' "four"}\n'
         ),
     )
+    eq_test_nrows("SELECT * FROM json", [], data="")
 
     # CSV input and NULLs
     eq_test_nrows(
@@ -575,6 +576,7 @@ def test_processors():
         data=",2,3\n4,5.0,ola\n,,",
         options=["-Idelimiter=,", "-Iheader=False"],
     )
+    eq_test_nrows("SELECT * FROM csv", [], data="")
 
     # Text input and NULLs
     eq_test_nrows(
@@ -587,6 +589,7 @@ def test_processors():
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
         data="\n4\noops",
     )
+    eq_test_nrows("SELECT * FROM text", [], data="")
 
     # SPy input and NULLs
     eq_test_nrows(
@@ -624,6 +627,7 @@ def test_processors():
             ]
         ),
     )
+    eq_test_nrows("SELECT * FROM spy", [], data="")
 
 
 def test_metadata():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -27,9 +27,13 @@ def txt_output(out, has_header=False):
     return out.splitlines()
 
 
-def list_of_struct2pretty(vals):
-    if not vals:
+def list_of_struct2pretty(rows):
+    if not rows:
         return []
+    vals = [  # NULLs should be replaced by Nones before calling tabulate
+        {key: (None if val is NULL else val) for (key, val) in row.items()}
+        for row in rows
+    ]
     return (tabulate(vals, headers="keys", tablefmt="simple") + "\n").splitlines()
 
 
@@ -818,5 +822,8 @@ def test_sql_output():
 
 
 def test_plot_output():
+    # just checking that it does not break...
     res = run_spyql("SELECT col1 as abc, col1*2 FROM range(20) TO plot")
-    assert res.exit_code == 0  # just checking that it does not break...
+    assert res.exit_code == 0
+    res = run_spyql("SELECT col1 FROM [1,2,NULL,3,None,4] TO plot")
+    assert res.exit_code == 0

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -626,6 +626,107 @@ def test_processors():
     )
 
 
+def test_metadata():
+    eq_test_nrows(
+        "SELECT cols, _values, _names, row FROM csv",
+        [
+            {
+                "cols": [NULL, 2, 3],
+                "_values": ["", "2", "3"],
+                "_names": ["a", "b", "c"],
+                "row": {"a": NULL, "b": 2, "c": 3},
+            },
+            {
+                "cols": [4, 5, 6],
+                "_values": ["4", "5", "6"],
+                "_names": ["a", "b", "c"],
+                "row": {"a": 4, "b": 5, "c": 6},
+            },
+            {
+                "cols": [NULL, 8, 9],
+                "_values": ["", "8", "9"],
+                "_names": ["a", "b", "c"],
+                "row": {"a": NULL, "b": 8, "c": 9},
+            },
+        ],
+        data="a,b,c\n,2,3\n4,5,6\n,8,9",
+    )
+    eq_test_nrows(
+        "SELECT cols, _values, _names, row FROM csv",
+        [
+            {
+                "cols": [NULL, 2, 3],
+                "_values": ["", "2", "3"],
+                "_names": ["col1", "col2", "col3"],
+                "row": {"col1": NULL, "col2": 2, "col3": 3},
+            },
+            {
+                "cols": [4, 5, 6],
+                "_values": ["4", "5", "6"],
+                "_names": ["col1", "col2", "col3"],
+                "row": {"col1": 4, "col2": 5, "col3": 6},
+            },
+            {
+                "cols": [NULL, 8, 9],
+                "_values": ["", "8", "9"],
+                "_names": ["col1", "col2", "col3"],
+                "row": {"col1": NULL, "col2": 8, "col3": 9},
+            },
+        ],
+        data=",2,3\n4,5,6\n,8,9",
+        options=["-Idelimiter=,", "-Iheader=False"],
+    )
+    eq_test_1row(
+        "SELECT cols, _values, _names, row FROM json",
+        {
+            "cols": [{"a": 1}],
+            "_values": [{"a": 1}],
+            "_names": ["json"],
+            "row": {"json": {"a": 1}},
+        },
+        data='{"a": 1}\n',
+    )
+    eq_test_1row(
+        "SELECT cols, _values, _names, row FROM text",
+        {
+            "cols": ["hello"],
+            "_values": ["hello"],
+            "_names": ["col1"],
+            "row": {"col1": "hello"},
+        },
+        data="hello\n",
+    )
+    eq_test_nrows(
+        "SELECT cols, _values, _names, row FROM spy",
+        [
+            {
+                "cols": [1, NULL, 3],
+                "_values": [1, NULL, 3],
+                "_names": ["a", "b", "c"],
+                "row": {"a": 1, "b": NULL, "c": 3},
+            },
+            {
+                "cols": [4, 5, 6],
+                "_values": [4, 5, 6],
+                "_names": ["a", "b", "c"],
+                "row": {"a": 4, "b": 5, "c": 6},
+            },
+            {
+                "cols": [7, 8, 9],
+                "_values": [7, 8, 9],
+                "_names": ["a", "b", "c"],
+                "row": {"a": 7, "b": 8, "c": 9},
+            },
+        ],
+        data="".join(
+            [
+                SpyWriter.pack(line)
+                for line in [["a", "b", "c"], [1, NULL, 3], [4, 5, 6], [7, 8, 9]]
+            ]
+        ),
+    )
+
+
 def test_custom_syntax():
     # easy access to dic fields
     eq_test_1row(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -532,25 +532,47 @@ def test_processors():
 
     # CSV input and NULLs
     eq_test_nrows(
-        "SELECT int(a) as a FROM csv",
+        "SELECT a as a FROM csv",
         [{"a": 1}, {"a": 4}, {"a": 7}],
         data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
     )
     eq_test_nrows(
-        "SELECT int(a) as a FROM csv",
+        "SELECT a as a FROM csv",
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
-        data="a,b,c\n,2,3\n4,5,6\noops,8,9",
+        data="a,b,c\n,2,3\n4,5,6\n,8,9",
     )
     eq_test_nrows(
-        "SELECT int(a) as a FROM csv",
+        "SELECT a as a FROM csv",
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
-        data="a,b,c\n,2,3\n4,5,6\noops,8,9",
+        data="a,b,c\n,2,3\n4,5,6\n,8,9",
         options=["-Idelimiter=,"],
     )
     eq_test_nrows(
-        "SELECT int(col1) as a FROM csv",
+        "SELECT int(a) as a FROM csv",
         [{"a": NULL}, {"a": 4}, {"a": NULL}],
-        data=",2,3\n4,5,6\noops,8,9",
+        data="a,b,c\n,2,3\n4,5,6\noops,8,9",
+        options=["-Idelimiter=,", "-Iinfer_dtypes=False"],
+    )
+    eq_test_nrows(
+        "SELECT a as a FROM csv",
+        [{"a": ""}, {"a": "4"}, {"a": ""}],
+        data="a,b,c\n,2,3\n4,5,6\n,8,9",
+        options=["-Idelimiter=,", "-Iinfer_dtypes=False"],
+    )
+    eq_test_nrows(
+        "SELECT col1 as a FROM csv",
+        [{"a": NULL}, {"a": 4}, {"a": NULL}],
+        data=",2,3\n4,5,6\n,8,9",
+        options=["-Idelimiter=,", "-Iheader=False"],
+    )
+    eq_test_nrows(
+        "SELECT col1 as a, col2 as b, col3 as c FROM csv",  # type inference test
+        [
+            {"a": NULL, "b": 2.0, "c": "3"},
+            {"a": 4, "b": 5.0, "c": "ola"},
+            {"a": NULL, "b": NULL, "c": ""},
+        ],
+        data=",2,3\n4,5.0,ola\n,,",
         options=["-Idelimiter=,", "-Iheader=False"],
     )
 


### PR DESCRIPTION
This PR adds:

- Inference of basic data type (int, float, complex) for columns in CSV files. Resilient to NULLs. Defaults as string.
- `cols` var/translation gets list of columns' values for the current record (after type casting)
- `_values` var holds the list of columns' values for the current record (before type casting). Should be equivalent to `cols` except on CSVs.
- `row` var/translation returns a dictionary with the current row (col names as keys, `cols` as values)
- `_names` var holds the list of column names

Minor bugs and improvements (see list of commits).

This PR will expire in 24 hours :-)  
I will merge to master by then if there's no feedback. 