### PR TITLE
feat: add * operator EXCEPT modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Right now, the focus is on building a command-line tool that follows these core 
 ```sql
 [ IMPORT python_module [ AS identifier ] [, ...] ]
 SELECT [ DISTINCT | PARTIALS ] 
-    [ * | python_expression [ AS output_column_name ] [, ...] ]
+    [ * [EXCEPT (column_name [, ...])]
+        | python_expression [ AS output_column_name ] [, ...] ]
     [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
     [ WHERE python_expression ]
     [ GROUP BY output_column_number | python_expression  [, ...] ]

--- a/spyql/cli.py
+++ b/spyql/cli.py
@@ -182,12 +182,16 @@ def parse_select(sel, strings):
 
     res = []
     as_pattern = re.compile(r"\s+AS\s+", re.IGNORECASE)
+    except_pattern = re.compile(r"\*\s*EXCEPT\s*\(.*\)", re.IGNORECASE)
     for expr in split_multi_expr_clause(sel):
-        sas = re.search(as_pattern, expr)
+        as_match = re.search(as_pattern, expr)
+        except_match = re.search(except_pattern, expr)
         name = ""
-        if sas:
-            name = expr[(sas.span()[1]) :].strip()
-            expr = expr[: (sas.span()[0])]
+        if as_match:
+            name = expr[(as_match.span()[1]) :].strip()
+            expr = expr[: (as_match.span()[0])]
+        elif except_match:
+            name = expr
         else:
             # automatic output column name from expression
             # removes json 'variable' reference (visual garbage)
@@ -398,7 +402,8 @@ def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
     \b
     [ IMPORT python_module [ AS identifier ] [, ...] ]
     SELECT [ DISTINCT | PARTIALS ]
-        [ * | python_expression [ AS output_column_name ] [, ...] ]
+        [ * [EXCEPT (column_name [, ...])]
+            | python_expression [ AS output_column_name ] [, ...] ]
         [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
         [ WHERE python_expression ]
         [ GROUP BY output_column_number | python_expression  [, ...] ]

--- a/spyql/prof.py
+++ b/spyql/prof.py
@@ -1,9 +1,9 @@
 import cProfile
-import spyql.cli
+import spyql.cli  # noqa: F401
 
 """
-Run `python3 -m spyql.prof <my_query>` for profiling. 
-Profiler stats saved on file `spyql.stats`. 
+Run `python3 -m spyql.prof <my_query>` for profiling.
+Profiler stats saved on file `spyql.stats`.
 """
 
 if __name__ == "__main__":

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -193,6 +193,52 @@ def test_basic():
     )
 
 
+def test_except():
+
+    # get all columns except one from a CSV
+    eq_test_nrows(
+        "SELECT * EXCEPT (b) FROM csv",
+        [{"a": 1, "c": 3}, {"a": 4, "c": 6}, {"a": 7, "c": 9}],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+    eq_test_nrows(
+        "SELECT * EXCEPT(b) FROM csv",
+        [{"a": 1, "c": 3}, {"a": 4, "c": 6}, {"a": 7, "c": 9}],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+    # get all columns except two from a CSV
+    eq_test_nrows(
+        "SELECT * EXCEPT(a,c) FROM csv",
+        [{"b": 2}, {"b": 5}, {"b": 8}],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+    eq_test_nrows(
+        "SELECT * EXCEPT ( a , c ) FROM csv",
+        [{"b": 2}, {"b": 5}, {"b": 8}],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+    # get one column and all except one from a CSV
+    eq_test_nrows(
+        "SELECT b, * EXCEPT (b) FROM csv",
+        [{"b": 2, "a": 1, "c": 3}, {"b": 5, "a": 4, "c": 6}, {"b": 8, "a": 7, "c": 9}],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+    eq_test_nrows(
+        "SELECT b AS banana, * EXCEPT (c) FROM csv",
+        [
+            {"banana": 2, "a": 1, "b": 2},
+            {"banana": 5, "a": 4, "b": 5},
+            {"banana": 8, "a": 7, "b": 8},
+        ],
+        data="a,b,c\n1,2,3\n4,5,6\n7,8,9",
+    )
+
+
 def test_orderby():
     # order by (1 col)
     eq_test_nrows(


### PR DESCRIPTION
Adds the * operator EXCEPT modifier where one can specify the names of one or more columns to exclude from the result. All matching column names are omitted from the output.