### PR TITLE
LIKE clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Right now, the focus is on building a command-line tool that follows these core 
 SELECT [ DISTINCT | PARTIALS ] 
     [ * | python_expression [ AS output_column_name ] [, ...] ]
     [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
-    [ WHERE python_expression ]
+    [ WHERE python_expression [ [NOT] LIKE string] ]
     [ GROUP BY output_column_number | python_expression  [, ...] ]
     [ ORDER BY output_column_number | python_expression
         [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]

--- a/spyql/cli.py
+++ b/spyql/cli.py
@@ -437,7 +437,7 @@ def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
     SELECT [ DISTINCT | PARTIALS ]
         [ * | python_expression [ AS output_column_name ] [, ...] ]
         [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
-        [ WHERE python_expression ]
+        [ WHERE python_expression [ [NOT] LIKE string] ]
         [ GROUP BY output_column_number | python_expression  [, ...] ]
         [ ORDER BY output_column_number | python_expression
             [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]

--- a/spyql/quotes_handler.py
+++ b/spyql/quotes_handler.py
@@ -9,6 +9,9 @@ class QuotesHandler:
     def __init__(self):
         self.strings = {}
 
+    def __iter__(self):
+        return iter(self.strings)
+
     # replaces quoted strings by placeholders to make parsing easier
     # populates dictionary of placeholders and the strings they hold
     def extract_strings(self, query):


### PR DESCRIPTION
Adds a LIKE function to the WHERE clause for easier matching. Closes #17 

### Some notes
- Right now it can match not only with strings but also with everything else, as the values are *stringified* before matching. Let me know if this is not intended and if it should be for strings only.
- It only supports the `%` wildcard operator.
- Let me know if the commit messages should follow a specific format

### Future work
Either in the scope of this PR or in a future one, it is still missing [other basic matching functions](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql?view=sql-server-ver15#arguments), like `_` for single character matching or `[]` to specify a range.