### PR TITLE
JSON external libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Right now, the focus is on building a command-line tool that follows these core 
 [ IMPORT python_module [ AS identifier ] [, ...] ]
 SELECT [ DISTINCT | PARTIALS ] 
     [ * | python_expression [ AS output_column_name ] [, ...] ]
-    [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
+    [ FROM csv | spy | text | python_expression | orjson | json [ EXPLODE path ] ]
     [ WHERE python_expression ]
     [ GROUP BY output_column_number | python_expression  [, ...] ]
     [ ORDER BY output_column_number | python_expression

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Output:
 {"message": "Hello world", "three": 3}
 ```
 
+SPyQL supports reading/writing json data using [orjson](https://github.com/ijl/orjson), a fast, correct JSON library for Python. To use orjson, you need to [install it](https://github.com/ijl/orjson#install) separately. Then, test it, run the last again changing `json` to `orjson`:
+
+```sh
+spyql "SELECT 'Hello world' as message, 1+2 as three TO orjson"
+```
+Output:
+```json
+{"message":"Hello world","three":3}
+```
+
+
 ## Principles
 
 Right now, the focus is on building a command-line tool that follows these core principles:
@@ -90,7 +101,7 @@ Right now, the focus is on building a command-line tool that follows these core 
 
 ```sql
 [ IMPORT python_module [ AS identifier ] [, ...] ]
-SELECT [ DISTINCT | PARTIALS ] 
+SELECT [ DISTINCT | PARTIALS ]
     [ * | python_expression [ AS output_column_name ] [, ...] ]
     [ FROM csv | spy | text | python_expression | orjson | json [ EXPLODE path ] ]
     [ WHERE python_expression ]
@@ -99,7 +110,7 @@ SELECT [ DISTINCT | PARTIALS ]
         [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
     [ LIMIT row_count ]
     [ OFFSET num_rows_to_skip ]
-    [ TO csv | json | spy | sql | pretty | plot ]
+    [ TO csv | orjson | json | spy | sql | pretty | plot ]
 ```
 
 
@@ -117,7 +128,7 @@ In SpyQL:
 
 | Operation | PostgreSQL | SpyQL |
 | --------- | ---------- | ----- |
-| Sum all values of a column | `SELECT sum(col_name)` | `SELECT sum_agg(col_name)` | 
+| Sum all values of a column | `SELECT sum(col_name)` | `SELECT sum_agg(col_name)` |
 | Sum an array | `SELECT sum(a) FROM (SELECT unnest(array[1,2,3]) AS a) AS t` | `SELECT sum([1,2,3])` |
 
 
@@ -290,11 +301,11 @@ ORDER BY 1
 
 ### Partial aggregations
 
-Calculating the cumulative sum of a variable using the `PARTIALS` modifier. Also demoing the lag aggregator. 
+Calculating the cumulative sum of a variable using the `PARTIALS` modifier. Also demoing the lag aggregator.
 
 ```sql
-SELECT PARTIALS 
-    json->new_entries, 
+SELECT PARTIALS
+    json->new_entries,
     sum_agg(json->new_entries) AS cum_new_entries,
     lag(json->new_entries) AS prev_entries
 FROM json
@@ -322,7 +333,7 @@ Output:
 {"new_entries" : 100,  "cum_new_entries" : 140, "prev_entries": null}
 ```
 
-If `PARTIALS`was omitted the result would be equivalent to the last output row. 
+If `PARTIALS`was omitted the result would be equivalent to the last output row.
 
 ### Distinct rows
 
@@ -401,11 +412,11 @@ spyql --unbuffered "
 	SELECT PARTIALS
         count_agg(*) AS running_count,
 		sum_agg(value) AS running_sum,
-		min_agg(value) AS min_so_far, 
+		min_agg(value) AS min_so_far,
         value AS current_value
 	FROM json
 	TO csv
-" 
+"
 ```
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==19.2.3
+pip==21.1
 bump2version==0.5.11
 wheel==0.33.6
 flake8==3.7.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ black==21.7b0
 numpy
 myst-parser
 codecov
+orjson==3.5.4

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requirements = [
 test_requirements = [
     "pytest>=3",
     "numpy",
+    "orjson",
 ]
 
 setup(

--- a/spyql/cli.py
+++ b/spyql/cli.py
@@ -75,7 +75,7 @@ def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
     [ IMPORT python_module [ AS identifier ] [, ...] ]
     SELECT [ DISTINCT | PARTIALS ]
         [ * | python_expression [ AS output_column_name ] [, ...] ]
-        [ FROM csv | spy | text | python_expression | json [ EXPLODE path ] ]
+        [ FROM csv | spy | text | python_expression | orjson | json [ EXPLODE path ] ]
         [ WHERE python_expression ]
         [ GROUP BY output_column_number | python_expression  [, ...] ]
         [ ORDER BY output_column_number | python_expression

--- a/spyql/cli.py
+++ b/spyql/cli.py
@@ -82,7 +82,7 @@ def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
             [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
         [ LIMIT row_count ]
         [ OFFSET num_rows_to_skip ]
-        [ TO csv | json | spy | sql | pretty | plot ]
+        [ TO csv | orjson | json | spy | sql | pretty | plot ]
     """
 
     out = Query(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -112,6 +112,10 @@ def eq_test_nrows(query, expectation, data=None, **kw_options):
     assert json_output(res.output) == expectation
     assert res.exit_code == 0
 
+    res = run_cli(query + " TO orjson", options, data, runner)
+    assert json_output(res.output) == expectation
+    assert res.exit_code == 0
+
     res = run_cli(query + " TO csv", options, data, runner)
     assert txt_output(res.output, True) == list_of_struct2csv(expectation)
     assert res.exit_code == 0

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -559,25 +559,38 @@ def test_null():
 
 def test_processors():
     # JSON input and NULLs
-    eq_test_1row("SELECT json.a FROM json", {"a": 1}, data='{"a": 1}\n')
-    eq_test_1row("SELECT json.a FROM json", {"a": NULL}, data='{"a": null}\n')
-    eq_test_1row("SELECT json.b FROM json", {"b": NULL}, data='{"a": 1}\n')
+    for jsonproc in ["json", "orjson"]:
+        eq_test_1row(
+            f"SELECT json.a FROM {jsonproc}",
+            {"a": 1},
+            data='{"a": 1}\n',
+        )
+        eq_test_1row(
+            f"SELECT json.a FROM {jsonproc}",
+            {"a": NULL},
+            data='{"a": null}\n',
+        )
+        eq_test_1row(
+            f"SELECT json.b FROM {jsonproc}",
+            {"b": NULL},
+            data='{"a": 1}\n',
+        )
 
-    # JSON EXPLODE
-    eq_test_nrows(
-        "SELECT json.a, json.b FROM json EXPLODE json.a",
-        [
-            {"a": 1, "b": "three"},
-            {"a": 2, "b": "three"},
-            {"a": 3, "b": "three"},
-            {"a": 4, "b": "four"},
-        ],
-        data=(
-            '{"a": [1, 2, 3], "b": "three"}\n{"a": [], "b": "none"}\n{"a": [4], "b":'
-            ' "four"}\n'
-        ),
-    )
-    eq_test_nrows("SELECT * FROM json", [], data="")
+        # JSON EXPLODE
+        eq_test_nrows(
+            f"SELECT json.a, json.b FROM {jsonproc} EXPLODE json.a",
+            [
+                {"a": 1, "b": "three"},
+                {"a": 2, "b": "three"},
+                {"a": 3, "b": "three"},
+                {"a": 4, "b": "four"},
+            ],
+            data=(
+                '{"a": [1, 2, 3], "b": "three"}\n{"a": [], "b": "none"}\n{"a": [4], "b":'
+                ' "four"}\n'
+            ),
+        )
+        eq_test_nrows(f"SELECT * FROM {jsonproc}", [], data="")
 
     # CSV input and NULLs
     eq_test_nrows(


### PR DESCRIPTION
There are JSON encoding/decoding libraries delivering higher performance than the standard library.
This PR proposes a way to use  [orjson](https://github.com/ijl/orjson) for processing and writing JSONs.
JSON encoding with the standard library was also improved by creating the encoder on the constructor.

orjson was not considered a dependency. The user has to install it separately: https://github.com/ijl/orjson#install.

Decoding benchmarks with a JSON file of 674MB (1.000.000 records):
```sh
$time spyql "SELECT avg_agg(json->overall) FROM json" < sample.json > /dev/null  
12,55s user 0,40s system 89% cpu 14,437 total

$time spyql "SELECT avg_agg(json->overall) FROM orjson" < sample.json > /dev/null
8,98s user 0,33s system 98% cpu 9,483 total

$time jq -n '[inputs.overall] | add/length' sample.json > /dev/null
12,04s user 0,24s system 99% cpu 12,386 total
```

Simple encoding benchmarks:

<pre><code><del>$time spyql "select col1 from range(1000000) to json" > /dev/null</del>
<del>6,94s user 0,15s system 97% cpu 7,248 total</del></pre></code>
```sh
$time spyql "select col1 from range(1000000) to json" > /dev/null
5,06s user 0,20s system 96% cpu 5,454 total

$time spyql "select col1 from range(1000000) to orjson" > /dev/null
3,30s user 0,15s system 102% cpu 3,364 total
```

