### PR TITLE
Key-value aggregations and lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ FROM csv
 ```
 
 
+
 ## Command line examples
 
 To run the following examples, type `Ctrl-x Ctrl-e` on you terminal. This will open your default editor (emacs/vim). Paste the code of one of the examples, save and exit.
@@ -433,6 +434,55 @@ spyql "
 	TO spy" |
 spyql "SELECT full_name, full_name.upper() FROM spy"
 ```
+
+
+### (Equi) Joins
+
+It is possible to make simple (LEFT) JOIN operations based on dictionary lookups.
+
+Given `numbers.json`:
+```json
+{
+	"1": "One",
+	"2": "Two",
+	"3": "Three"
+}
+```
+
+Query:
+```sh
+spyql -Jnums=numbers.json "
+	SELECT nums[col1] as res
+	FROM [3,4,1,1]
+	TO json"
+```
+
+Output:
+
+```json
+{"res": "Three"}
+{"res": null}
+{"res": "One"}
+{"res": "One"}
+```
+
+If you want a INNER JOIN instead of a LEFT JOIN, you can add a criteria to the where clause, e.g.:
+
+```sql
+SELECT nums[col1] as res
+FROM [3,4,1,1]
+WHERE col1 in nums
+TO json
+```
+
+Output:
+
+```json
+{"res": "Three"}
+{"res": "One"}
+{"res": "One"}
+```
+
 
 ### Queries over APIs
 

--- a/spyql/agg.py
+++ b/spyql/agg.py
@@ -8,6 +8,7 @@
 
 import operator
 from spyql.nulltype import Null
+from spyql.qdict import qdict
 
 
 def _init_aggs():
@@ -118,6 +119,15 @@ def set_agg(val, respect_nulls=True):
     Filters out NULLs when `respect_nulls` is `False`.
     """
     return _agg_op(operator.or_, {val} if respect_nulls or val is not Null else set())
+
+
+def dict_agg(key, val):
+    """
+    Collects key-value pairs into a dict.
+    Key must be unique and not null (null keys are discarded).
+    In case of duplicated keys, the value returned is the last seen.
+    """
+    return _agg_op(operator.or_, qdict({key: val} if key is not Null else {}))
 
 
 def first_agg(val, respect_nulls=True):

--- a/spyql/agg.py
+++ b/spyql/agg.py
@@ -127,7 +127,10 @@ def dict_agg(key, val):
     Key must be unique and not null (null keys are discarded).
     In case of duplicated keys, the value returned is the last seen.
     """
-    return _agg_op(operator.or_, qdict({key: val} if key is not Null else {}))
+    return _agg_op(
+        lambda a_dict, an_entry: a_dict.updatef(an_entry),
+        qdict({key: val} if key is not Null else {}),
+    )
 
 
 def first_agg(val, respect_nulls=True):

--- a/spyql/agg.py
+++ b/spyql/agg.py
@@ -117,7 +117,7 @@ def set_agg(val, respect_nulls=True):
     Collects all distinct input values into a set.
     Filters out NULLs when `respect_nulls` is `False`.
     """
-    return _agg_op(operator.or_, {val} if respect_nulls or val is not Null else Null)
+    return _agg_op(operator.or_, {val} if respect_nulls or val is not Null else set())
 
 
 def first_agg(val, respect_nulls=True):

--- a/spyql/cli.py
+++ b/spyql/cli.py
@@ -39,6 +39,17 @@ def parse_options(ctx, param, options):
     ),
 )
 @click.option(
+    "-J",
+    "json_obj_files",
+    type=click.UNPROCESSED,
+    callback=parse_options,
+    multiple=True,
+    help=(
+        "Loads a JSON with a single object into memory 'var_name=file_name'. Example:"
+        " -Jnames=names.json"
+    ),
+)
+@click.option(
     "--unbuffered",
     "-u",
     is_flag=True,
@@ -66,7 +77,9 @@ def parse_options(ctx, param, options):
     ),
 )
 @click.version_option(version=spyql.__version__)
-def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
+def main(
+    query, warning_flag, verbose, unbuffered, input_opt, output_opt, json_obj_files
+):
     """
     Tool to run a SpyQL QUERY over text data.
     For more info visit: https://github.com/dcmoura/spyql
@@ -89,6 +102,7 @@ def main(query, warning_flag, verbose, unbuffered, input_opt, output_opt):
         query,
         input_opt,
         output_opt,
+        json_obj_files,
         unbuffered,
         warning_flag,
         verbose,

--- a/spyql/qdict.py
+++ b/spyql/qdict.py
@@ -89,3 +89,8 @@ class qdict(dict):
         # TODO check if this is sufficienly efficient...
         # This only needs to guarantee that two equivalent dicts have the same hash
         return hash(json.dumps(self, default=str, sort_keys=True))
+
+    def updatef(self, another_dict):
+        # same as update but returns the dict
+        self.update(another_dict)
+        return self

--- a/spyql/qdict.py
+++ b/spyql/qdict.py
@@ -94,3 +94,19 @@ class qdict(dict):
         # same as update but returns the dict
         self.update(another_dict)
         return self
+
+
+class str_qdict(qdict):
+    def __getitem__(self, key):
+        if key is NULL:
+            return NULL
+        return super().__getitem__(str(key))
+
+    def __contains__(self, key):
+        if key is NULL:
+            return False
+        return super().__contains__(str(key))
+
+    ## implement if needed:
+    # def __delitem__(self, key):
+    # def __setitem__(self, key, val):

--- a/spyql/query.py
+++ b/spyql/query.py
@@ -34,6 +34,7 @@ class Query:
         query: str,
         input_options: dict = {},
         output_options: dict = {},
+        json_obj_files: dict = {},
         unbuffered=False,
         warning_flag="default",
         verbose=0,
@@ -49,6 +50,9 @@ class Query:
         :type input_options: dict, optional
         :param output_options: options to be passed to the output writer.
             e.g. ``{"delimiter": ";", "header": False}``
+        :type output_options: dict, optional
+        :param output_options: JSON objects to load into memory.
+            e.g. ``{"names": "names.json", "colors": "warm_colors.json"}``
         :type output_options: dict, optional
         :param unbuffered: forces output to be unbuffered.
         :type unbuffered: bool, optional
@@ -71,6 +75,7 @@ class Query:
         self.parsed, self.strings = parse(query, default_to_clause)
         self.output_options = output_options
         self.input_options = input_options
+        self.json_obj_files = json_obj_files
         self.unbuffered = unbuffered
         self.__stats = None
 
@@ -79,6 +84,23 @@ class Query:
 
     def __repr__(self) -> str:
         return f'Query("{self.query}")'
+
+    def _load_json_objs(self):
+        import json
+        from spyql.qdict import str_qdict
+
+        objs = {}
+        for varname, filename in self.json_obj_files.items():
+            with open(filename, "r") as f:
+                try:
+                    objs[varname] = str_qdict(json.loads(f.read()))
+                except Exception as e:
+                    raise ValueError(
+                        "Error decoding JSON file: "
+                        + str(e)
+                        + "; expected a JSON file with a single object"
+                    )
+        return objs
 
     def __call__(self, **kwargs):
         """
@@ -89,6 +111,10 @@ class Query:
         processor = None
         result = None
         self.__stats = None
+
+        user_query_vars = self._load_json_objs()  # json objects are loaded as variables
+        user_query_vars.update(kwargs)  # key-value arguments are loaded as variables
+
         try:
             # make the processor
             processor = Processor.make_processor(
@@ -98,7 +124,7 @@ class Query:
             )
             result, self.__stats = processor.go(
                 output_options=self.output_options,
-                user_query_vars=kwargs,
+                user_query_vars=user_query_vars,
             )
         finally:
             # makes sure files are closed

--- a/spyql/sqlfuncs.py
+++ b/spyql/sqlfuncs.py
@@ -1,4 +1,5 @@
 from spyql.nulltype import NULL
+from spyql.qdict import qdict
 import spyql.log
 
 # functions that support NULLs (and that need to be replaced in the query)

--- a/tests/files_lib_test.py
+++ b/tests/files_lib_test.py
@@ -16,10 +16,10 @@ raw_data = [
 ]
 
 
-def make_json():
-    json_fpath = join_paths(gettempdir(), "spyql_test.jsonl")
+def make_json(data=raw_data, filename="spyql_test.jsonl"):
+    json_fpath = join_paths(gettempdir(), filename)
     with open(json_fpath, "w") as f:
-        for d in raw_data:
+        for d in data:
             f.write(json.dumps(d) + "\n")
     return json_fpath
 
@@ -168,14 +168,65 @@ def test_write_invalid_file():
 
 
 def test_equi_join():
-    query = Query("SELECT row.name, names[row.name] AS ext_name FROM data")
-    out = query(data=raw_data, names=qdict({"A": "Alice", "C": "Chris", "D": "Daniel"}))
-    assert out == (
+    query_str = "SELECT row.name, names[row.name] AS ext_name FROM data"
+    names_kv = qdict({"A": "Alice", "C": "Chris", "D": "Daniel"})
+    expectation = (
         {"name": "A", "ext_name": "Alice"},
         {"name": "B", "ext_name": NULL},
         {"name": "C", "ext_name": "Chris"},
         {"name": "D", "ext_name": "Daniel"},
     )
+
+    # key-value/dict as a variable
+    out = Query(query_str)(data=raw_data, names=names_kv)
+    assert out == expectation
+
+    # key-value/dict as a JSON file
+    kv_fpath = make_json([names_kv], "names.json")
+    out = Query(query_str, json_obj_files={"names": kv_fpath})(data=raw_data)
+    assert out == expectation
+
+    # two dicts from JSON files, auto-cast keys to str, and NULL keys handling
+    nums_kv = {"1": "One", "3": "Three"}
+    kv_fpath2 = make_json([nums_kv], "nums.json")
+    out = Query(
+        "SELECT names['C'] AS a, nums['1'] as b, nums[1] AS bn, nums[NULL] AS c",
+        json_obj_files={"names": kv_fpath, "nums": kv_fpath2},
+    )()
+    assert out == ({"a": "Chris", "b": "One", "bn": "One", "c": NULL},)
+
+    # test INNER JOIN (do not include records where the key is not in the dict)
+    out = Query(
+        "SELECT nums[col1] as n FROM [1,2,3] WHERE col1 in nums",
+        json_obj_files={"nums": kv_fpath2},
+    )()
+    assert out == ({"n": "One"}, {"n": "Three"})
+
+    # test NULL key
+    out = Query(
+        "SELECT NULL in nums AS n",
+        json_obj_files={"nums": kv_fpath2},
+    )()
+    assert out == ({"n": False},)
+    os.remove(kv_fpath)
+    os.remove(kv_fpath2)
+
+    # key-value/dict JSON file does not exist
+    kv_fpath = "this_file_should_not_exist..."
+    try:
+        Query(query_str, json_obj_files={"names": kv_fpath})(data=raw_data)
+        assert False
+    except FileNotFoundError:
+        assert True
+
+    # key-value/dict JSON file content is invalid (it is not a single object)
+    kv_fpath = make_json([{"A": "Alice"}, {"C": "Chris", "D": "Daniel"}], "names2.json")
+    try:
+        Query(query_str, json_obj_files={"names": kv_fpath})(data=raw_data)
+        assert False
+    except ValueError:
+        assert True
+    os.remove(kv_fpath)
 
 
 def test_globals():


### PR DESCRIPTION
This PR closes #59.

First, it introduces `dict_agg` for key-value aggregations. Example:

```
$ cat codes.csv
MCC,MCC (int),MNC,MNC (int),ISO,Country,Country Code,Network
289,649,88,2191,ge,Abkhazia,7,A-Mobile
289,649,68,1679,ge,Abkhazia,7,A-Mobile
289,649,67,1663,ge,Abkhazia,7,Aquafon
412,1042,01,31,af,Afghanistan,93,AWCC
412,1042,50,1295,af,Afghanistan,93,Etisalat
412,1042,30,783,af,Afghanistan,93,Etisalat
452,1106,04,79,vn,Vietnam,84,Viettel
452,1106,02,47,vn,Vietnam,84,VinaPhone
543,1347,299,665,wf,Wallis and Futuna,,Failed Calls
543,1347,01,31,wf,Wallis and Futuna,,Manuia
421,1057,999,2457,ye,Yemen,967,Fix Line
421,1057,04,79,ye,Yemen,967,HITS/Y Unitel
421,1057,01,31,ye,Yemen,967,Sabaphone
421,1057,03,63,ye,Yemen,967,Yemen Mob. CDMA
645,1605,01,31,zm,Zambia,260,Airtel
645,1605,299,665,zm,Zambia,260,Failed Calls

$ spyql "
    SELECT dict_agg(MCC, Country) AS json 
    FROM csv TO json
  " < codes.csv > code_country.json

$ jq . code_country.json                                        
{
  "289": "Abkhazia",
  "412": "Afghanistan",
  "452": "Vietnam",
  "543": "Wallis and Futuna",
  "421": "Yemen",
  "645": "Zambia"
}
```

Second, it introduces the ~~`kv` function~~ `-J` option to allow loading JSON objects for key-value lookups, emulating left equi joins. Example:

```sh
$ cat towers_mini.csv 
radio,mcc,net,area,cell,unit,lon,lat,range,samples,changeable,created,updated,averageSignal
UMTS,262,2,776,165186,0,13.329163,52.46521,1000,2,1,1286645042,1295769656,0
GSM,262,3,1075,5651,0,13.329163,52.46521,1000,2,1,1286645042,1295769656,0
UMTS,262,2,801,165123,0,13.295516967773,52.494735717773,1000,1,1,1286864565,1286864565,0
UMTS,262,2,801,165121,0,13.301697,52.499886,1000,4,1,1286884439,1297735807,0
GSM,624,2,6,13883,0,9.704361,4.063911,1588,8,1,1352031870,1374212876,0
GSM,624,2,6,34381,0,9.709009,4.066368,2484,13,1,1352031870,1380389330,0
GSM,452,1,10068,5293,0,105.8031463623,20.959854125977,1000,2,1,1459692342,1488347104,0
GSM,645,3,130,3282,0,28.070755004883,-14.902267456055,1000,1,1,1459743588,1459743588,0
GSM,645,3,1,32221,0,28.252716,-15.439224,1000,2,1,1369353852,1369353852,0
GSM,645,3,1,33932,0,28.255325,-15.436752,1000,5,1,1369353888,1369353888,0
GSM,645,3,1,31662,0,28.258072,-15.434555,1000,5,1,1369353960,1369353960,0

$ spyql -Jcountries=code_country.json "SELECT mcc, countries[mcc] AS country, count_agg(1) AS n_recs FROM csv GROUP BY 1, 2 ORDER BY 1 TO pretty" < towers_mini.csv
  mcc  country      n_recs
-----  ---------  --------
  262                    4
  452  Vietnam           1
  624                    2
  645  Zambia            4
```
