### PR TITLE
Universal access via a dot operator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+0.8.0 (2022-10-18)
+------------------
+* Added universal access to columns/fields via dot operator 
+
+
 0.7.1 (2022-10-10)
 ------------------
 * Tweaked JSON loading (via -J) to support any valid JSON file

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -895,6 +895,74 @@ def test_custom_syntax():
         {"six": 6, "caps": "HELLO WORLD"},
     )
 
+    eq_test_1row(
+        """
+        SELECT
+            .one,
+            .two.a,
+            json.two.b,
+            ._u_,
+            .1 as dot1,
+            0.2 as dot2,
+            [2,1,2,1,2].count(2) as rsb,
+            (3,3).count(3) as rrb,
+            len({}.keys()) as rcb,
+            (.one + 2) * 2 as lrb,
+            (10,20,30)[.one] as lsb,
+            {.one:'ok', 0:'bad'}[.one] as lcb,
+            sum([  .one, .one,.one]) as three,
+            {'a':.one }['a']+.one*.one/.one**.one-.one/.1 as arith,
+            ._u_.count(200)==.one as und,
+            'a'.upper() as str1,
+            "b".upper() as str2,
+            list(.keys()) as keys
+        FROM json
+        """,
+        {
+            "one": 1,
+            "two_a": 12,
+            "two_b": 13,
+            "_u_": [100, 200, 300],
+            "dot1": 0.1,
+            "dot2": 0.2,
+            "rsb": 3,
+            "rrb": 2,
+            "rcb": 0,
+            "lrb": 6,
+            "lsb": 20,
+            "lcb": "ok",
+            "three": 3,
+            "arith": -8.0,
+            "und": True,
+            "str1": "A",
+            "str2": "B",
+            "keys": ["one", "two", "_u_"],
+        },
+        data='{"one": 1, "two": {"a": 12, "b": 13}, "_u_": [100,200,300] }\n',
+    )
+
+    eq_test_1row(
+        """
+        SELECT
+            len(.),
+            {'all':.},
+            .,
+            list((.,)),
+            [.,.],
+            'one' in .
+        FROM json
+        """,
+        {
+            "len_row": 2,
+            "all_row": {"all": {"one": 1, "two": 2}},
+            "row": {"one": 1, "two": 2},
+            "list_row": [{"one": 1, "two": 2}],
+            "row_row": [{"one": 1, "two": 2}, {"one": 1, "two": 2}],
+            "one_in_row": True,
+        },
+        data='{"one": 1, "two": 2}\n',
+    )
+
 
 def test_errors():
     # TODO find way to test custom error output


### PR DESCRIPTION
This PR introduces the dot operator for universal access to the fields of different files formats. 

Consider the following files:

`data.csv`
```
a, b
1, 2
3, 4
```

`data.json`
```
{“a”: 1, “b”:2}
{“a”: 3, “b”:4}
```

Now we can use the same syntax to query from json and csv:

```
SELECT .a + .b FROM json
```
```
SELECT .a + .b FROM csv
```


Still, the following versions are more CPU efficient and should be considered when dealing with large files, especially in the CSV case:

```
SELECT json->a + json->b FROM json
```

```
SELECT a + b FROM csv
```

In the JSON case, using a lookup operator is faster than using an attribute access operator (this might be improved though).
In the CSV, it envolves creating a dictionary for each row (improving this would require changing the way we read CSVs and it would always be slower than reading each line as a list - as we do today).

This functionality was already available using the `row` keyword, the dot operator just makes it more practical and reduces clutter. Under the hood, `.a` is replaced by `row.a` before processing the query. This is done via regex, which is tricky (there might be some corner cases that I overlooked).

I am planning on doing a silent update (with no support on the README) since this is being addressed in the new documentation that should be released soon. 
