### PR TITLE
Fixed issued with parameters initialization

### DIFF
--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -7,7 +7,7 @@ import os
 from itertools import islice, chain
 from io import StringIO
 import copy
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 
 from spyql import agg, log, sqlfuncs
 from spyql.output_handler import OutputHandler
@@ -15,6 +15,7 @@ from spyql.query_result import QueryResult
 from spyql.qdict import qdict
 from spyql.utils import make_str_valid_varname, isiterable, is_row_collapsable
 from spyql.writer import Writer
+from spyql.quotes_handler import QuotesHandler
 
 
 def init_vars(user_query_vars={}):
@@ -67,11 +68,13 @@ class Processor:
         }
 
     @staticmethod
-    def make_processor(prs, strings, input_options={}):
+    def make_processor(prs: dict, strings: QuotesHandler, input_options: Optional[dict] = None):
         """
         Factory for making an input processor based on the parsed query
         """
         try:
+            if not input_options:
+                input_options = {}
             from_clause = prs["from"]
             processor_name = ""
             if not from_clause:  # no from close, single select eval

--- a/spyql/processor.py
+++ b/spyql/processor.py
@@ -68,7 +68,9 @@ class Processor:
         }
 
     @staticmethod
-    def make_processor(prs: dict, strings: QuotesHandler, input_options: Optional[dict] = None):
+    def make_processor(
+        prs: dict, strings: QuotesHandler, input_options: Optional[dict] = None
+    ):
         """
         Factory for making an input processor based on the parsed query
         """

--- a/spyql/query.py
+++ b/spyql/query.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 from spyql.parser import parse
 from spyql.processor import Processor
 from spyql import log
@@ -33,9 +34,9 @@ class Query:
     def __init__(
         self,
         query: str,
-        input_options: dict = {},
-        output_options: dict = {},
-        json_obj_files: dict = {},
+        input_options: Optional[dict] = None,
+        output_options: Optional[dict] = None,
+        json_obj_files: Optional[dict] = None,
         unbuffered=False,
         warning_flag="default",
         verbose=0,
@@ -74,9 +75,9 @@ class Query:
 
         self.query = query
         self.parsed, self.strings = parse(query, default_to_clause)
-        self.output_options = output_options
-        self.input_options = input_options
-        self.json_obj_files = json_obj_files
+        self.output_options = output_options if output_options else {}
+        self.input_options = input_options if input_options else {}
+        self.json_obj_files = json_obj_files if json_obj_files else {}
         self.unbuffered = unbuffered
         self.__stats = None
 

--- a/spyql/writer.py
+++ b/spyql/writer.py
@@ -5,6 +5,7 @@ import asciichartpy as chart
 from math import nan
 import sys
 import io
+from typing import Optional
 
 from spyql.log import user_debug, user_error
 from spyql.nulltype import NULL
@@ -28,11 +29,13 @@ class Writer:
         }
 
     @staticmethod
-    def make_writer(to_clause, output_options={}):
+    def make_writer(to_clause: dict, output_options: Optional[dict] = None):
         """
         Factory for making an output writer based on the parsed query
         """
         try:
+            if not output_options:
+                output_options = {}
             writer_name = to_clause
             if not to_clause:  # not TO clause, defaults to CSV
                 writer_name = "CSV"

--- a/tests/files_lib_test.py
+++ b/tests/files_lib_test.py
@@ -167,6 +167,21 @@ def test_write_invalid_file():
         assert True
 
 
+def test_io_parameters_memory():
+    try:
+        csv_fpath = make_csv()
+        Query(
+            f"SELECT name as first_name, age as user_age FROM csv('{csv_fpath}', delimiter=',') TO json(indent=4)"
+        )()
+        # if there is a memory effect, the input/output params will remain and will cause this query to fail:
+        Query("SELECT * FROM range(10) TO csv")()
+        assert True
+    except TypeError:
+        assert False
+    finally:
+        os.remove(csv_fpath)
+
+
 def test_equi_join():
     query_str = "SELECT row.name, names[row.name] AS ext_name FROM data"
     names_kv = qdict({"A": "Alice", "C": "Chris", "D": "Daniel"})


### PR DESCRIPTION
Python has a very peculiar way of handling default values... if we create an object as default value (e.g. empty dict), this object is created once at function definition time, and not each time the function is called. This was generating the following 'memory' behaviour: 

```python
from spyql.query import Query
Query('select 1 as hello to csv(delimiter=\',\')')() # this one works OK
Query('select col1 from range(10) TO pretty')() # this one not

# hello
# 1
# ERROR	Could not create 'pretty' writer
# TypeError: tabulate() got an unexpected keyword argument 'delimiter'
```

This PR fixes this behaviour by assigning `None` as default values that are then properly handled. 