### PR TITLE
Fixes git-actions tests on py3.6 and adds py3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,11 +12,15 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"


### PR DESCRIPTION
Python 3.6 env stopped launching. Seems to be related to an upgrade on ubuntu version and support for py3.6 was not included in the new version.

Solution based on https://github.com/actions/setup-python/issues/543#issuecomment-1335614916